### PR TITLE
feat: Make contact info text clickable to copy

### DIFF
--- a/src/components/portfolio/Contact.tsx
+++ b/src/components/portfolio/Contact.tsx
@@ -88,45 +88,25 @@ const Contact = () => {
                             <div className="text-sm text-muted-foreground">
                               {contact.label}
                             </div>
-                            {contact.href &&
-                            (contact.label === "Primary Email" ||
-                              contact.label === "Secondary Email" ||
-                              contact.label === "Phone") ? (
-                              <div className="flex items-center gap-2">
-                                <a
-                                  href={contact.href}
-                                  className="text-foreground font-medium transition-colors"
-                                  onMouseEnter={(e) =>
-                                    (e.currentTarget.style.color = `hsl(var(--primary))`)
-                                  }
-                                  onMouseLeave={(e) =>
-                                    (e.currentTarget.style.color = "")
-                                  }
-                                >
-                                  {contact.value}
-                                </a>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  type="button"
-                                  aria-label={`Copy ${contact.label}`}
-                                  onClick={() => {
-                                    navigator.clipboard.writeText(
-                                      contact.value
-                                    );
-                                    toast({
-                                      title: `${contact.label} copied!`,
-                                    });
-                                  }}
-                                >
-                                  <FaRegCopy className="h-4 w-4" />
-                                </Button>
-                              </div>
-                            ) : (
-                              <div className="text-foreground font-medium">
-                                {contact.value}
-                              </div>
-                            )}
+                            <div
+                              className="text-foreground font-medium cursor-pointer"
+                              onClick={() => {
+                                navigator.clipboard.writeText(contact.value);
+                                toast({
+                                  title: `${contact.label} copied!`,
+                                });
+                              }}
+                              onMouseEnter={(e) =>
+                                (e.currentTarget.style.color = `hsl(var(--primary))`)
+                              }
+                              onMouseLeave={(e) =>
+                                (e.currentTarget.style.color = "")
+                              }
+                              role="button"
+                              aria-label={`Copy ${contact.label}`}
+                            >
+                              {contact.value}
+                            </div>
                           </div>
                         </div>
                       ))}


### PR DESCRIPTION
Removed the explicit copy buttons from the contact section and made the contact information text itself clickable to copy the value to the clipboard.

This change improves the experience for your users by simplifying the interface and making the copy action more intuitive.

- Replaced copy buttons with an onClick handler on the text container.
- Applied this functionality to email, phone number, and location.
- Added a cursor pointer and hover effect to indicate clickability.